### PR TITLE
Add hydraulic range overview and category detail pages

### DIFF
--- a/app/products/page.js
+++ b/app/products/page.js
@@ -5,6 +5,11 @@ import { FeatureGrid } from '../../components/FeatureGrid';
 
 const categories = [
   {
+    title: 'Hydraulic Equipment Range',
+    description: 'Explore 25+ product families covering hydraulic power, bolting, filtration, and maintenance tooling.',
+    link: { href: '/products/range', label: 'View Range Overview' }
+  },
+  {
     title: 'Power Team (Hydraulics)',
     description: 'Pumps, cylinders, presses, and accessories engineered for demanding operations.',
     link: { href: '/products/power-team', label: 'Explore Power Team' }

--- a/app/products/range/[slug]/page.js
+++ b/app/products/range/[slug]/page.js
@@ -1,0 +1,61 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { PageIntro } from '../../../../components/PageIntro';
+import { Section } from '../../../../components/Section';
+import { productRangeCategories } from '../../../../data/productRange';
+import styles from '../../../../styles/ProductRangeDetail.module.css';
+
+function getCategory(slug) {
+  return productRangeCategories.find((category) => category.slug === slug);
+}
+
+export function generateMetadata({ params }) {
+  const category = getCategory(params.slug);
+  if (!category) {
+    return {
+      title: 'Product Category Not Found',
+      description: 'The requested product category could not be located.'
+    };
+  }
+
+  return {
+    title: `${category.title} – Hydraulic Equipments and Tools`,
+    description: `Discover featured equipment, highlights, and use cases for ${category.title.toLowerCase()}.`
+  };
+}
+
+export default function ProductRangeDetailPage({ params }) {
+  const category = getCategory(params.slug);
+
+  if (!category) {
+    notFound();
+  }
+
+  return (
+    <>
+      <PageIntro
+        title={category.title}
+        tagline="Featured equipment"
+        description={category.description}
+      >
+        <Link href="/products/range" className="button">
+          Back to range overview
+        </Link>
+      </PageIntro>
+      <Section
+        eyebrow="Highlighted Products"
+        title={`Explore ${category.items.length} featured solution${category.items.length === 1 ? '' : 's'}`}
+        description="Each item below showcases how Meceleon supports maintenance, assembly, and process reliability across industries."
+      >
+        <div className={styles.grid}>
+          {category.items.map((item) => (
+            <article key={item.name} className={styles.card}>
+              <h3>{item.name}</h3>
+              {item.summary && <p>{item.summary}</p>}
+            </article>
+          ))}
+        </div>
+      </Section>
+    </>
+  );
+}

--- a/app/products/range/page.js
+++ b/app/products/range/page.js
@@ -1,0 +1,29 @@
+import { PageIntro } from '../../../components/PageIntro';
+import { Section } from '../../../components/Section';
+import { ProductRangeGrid } from '../../../components/ProductRangeGrid';
+import { productRangeCategories } from '../../../data/productRange';
+
+export const metadata = {
+  title: 'Hydraulic Equipments and Tools Range',
+  description:
+    'Browse hydraulic tools, pumps, filtration systems, and maintenance equipment across the full Meceleon range.'
+};
+
+export default function ProductRangePage() {
+  return (
+    <>
+      <PageIntro
+        title="Hydraulic Equipments and Tools"
+        tagline="Comprehensive product range"
+        description="Explore over two dozen specialised categories that cover hydraulic power, bolting, filtration, and material handling."
+      />
+      <Section
+        eyebrow="Product Range"
+        title="Engineered solutions for every maintenance challenge"
+        description="Navigate the categories below to view detailed specifications and featured equipment drawn from the Meceleon catalogue."
+      >
+        <ProductRangeGrid categories={productRangeCategories} />
+      </Section>
+    </>
+  );
+}

--- a/components/ProductRangeGrid.jsx
+++ b/components/ProductRangeGrid.jsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import styles from '../styles/ProductRangeGrid.module.css';
+
+export function ProductRangeGrid({ categories }) {
+  return (
+    <div className={styles.grid}>
+      {categories.map((category) => (
+        <article key={category.slug} className={styles.card}>
+          <div className={styles.header}>
+            <h3>{category.title}</h3>
+            <p>{category.description}</p>
+          </div>
+          <ul className={styles.list}>
+            {category.items.map((item) => (
+              <li key={item.name}>
+                <span className={styles.itemName}>{item.name}</span>
+                {item.summary && <p>{item.summary}</p>}
+              </li>
+            ))}
+          </ul>
+          <Link href={`/products/range/${category.slug}`} className={styles.link}>
+            View details
+          </Link>
+        </article>
+      ))}
+    </div>
+  );
+}

--- a/data/navigation.js
+++ b/data/navigation.js
@@ -4,6 +4,7 @@ export const navLinks = [
     href: '/products',
     label: 'Products',
     children: [
+      { href: '/products/range', label: 'Hydraulic Equipment Range' },
       { href: '/products/power-team', label: 'Power Team' },
       { href: '/products/bolting-systems', label: 'Bolting Systems' },
       { href: '/products/pullers', label: 'Pullers' }

--- a/data/productRange.js
+++ b/data/productRange.js
@@ -1,0 +1,558 @@
+export const productRangeCategories = [
+  {
+    slug: 'high-pressure-hydraulic-tools',
+    title: 'High Pressure Hydraulic Tools',
+    description:
+      'Two-speed hydraulic hand pumps and tooling engineered for field maintenance where controlled force and portability matter.',
+    items: [
+      {
+        name: 'P59F Hydraulic Hand Pumps',
+        summary:
+          'Compact, two-speed pump delivering rapid low-pressure output with a high-pressure stage for precise tool actuation.'
+      },
+      {
+        name: 'P157/P159 Hydraulic Hand Pumps',
+        summary:
+          'Durable steel reservoir pumps built for repeated cycles in production, maintenance, and pulling applications.'
+      },
+      {
+        name: 'P460 Hydraulic Hand Pumps',
+        summary:
+          'High-capacity hand pump with ergonomic grip that maintains flow rates even under extreme system pressure.'
+      }
+    ]
+  },
+  {
+    slug: 'manual-powered-hand-tools-and-storage-solutions',
+    title: 'Manual, Powered Hand Tools And Storage Solutions',
+    description:
+      'Industrial torque tooling and storage options that keep critical fasteners and accessories protected on the job.',
+    items: [
+      {
+        name: 'CTECH2Y100A Industrial Torque Wrench',
+        summary:
+          'Electronic torque wrench with a high-visibility display that confirms precise tightening sequences.'
+      },
+      {
+        name: 'BRUTUS3R300 Torque Wrench',
+        summary:
+          'Heavy-duty reversible torque wrench designed to withstand harsh plant environments and frequent use.'
+      },
+      {
+        name: 'ATECH1FS240 Digital Micro Torque Wrench',
+        summary:
+          'Compact digital wrench offering fine torque resolution for delicate assembly and calibration tasks.'
+      }
+    ]
+  },
+  {
+    slug: 'power-team-hydraulic-products-and-tools',
+    title: 'Power Team Hydraulic Products And Tools',
+    description:
+      'Essential Power Team accessories that extend hydraulic systems, from cutting to lifting and controlled movement.',
+    items: [
+      {
+        name: 'HNS150 Nut Splitter Single Acting',
+        summary:
+          'Single-acting nut splitter that safely removes seized fasteners without damaging studs or bolts.'
+      },
+      {
+        name: 'Polyurethane Rubber Hoses',
+        summary:
+          'Lightweight, abrasion-resistant hoses rated for high-pressure applications and rigorous routing.'
+      },
+      {
+        name: 'Low Profile Bottle Jacks',
+        summary:
+          'Compact jacks that deliver impressive lifting capacity in tight service bays and maintenance pits.'
+      }
+    ]
+  },
+  {
+    slug: 'industrial-coupling-and-accessories',
+    title: 'Industrial Coupling and Accessories',
+    description:
+      'Connectors and accumulator components that safeguard hydraulic circuits and keep uptime high.',
+    items: [
+      {
+        name: 'Bladder for Accumulator',
+        summary:
+          'Replacement elastomer bladders engineered for long service life and consistent energy storage.'
+      },
+      {
+        name: 'Accumulator',
+        summary:
+          'Robust accumulator assemblies that smooth pressure spikes and stabilize hydraulic systems.'
+      },
+      {
+        name: 'Diaphragm Accumulator',
+        summary:
+          'Compact diaphragm-style accumulators ideal for pulsation damping and emergency power support.'
+      }
+    ]
+  },
+  {
+    slug: 'hydraulic-accumulator-oil-coolers-and-accessories',
+    title: 'Hydraulic Accumulator, Oil Coolers and Accessories',
+    description:
+      'Energy storage and cooling solutions that keep hydraulic power units operating safely and efficiently.',
+    items: [
+      {
+        name: 'Hydraulic Bladder Accumulator',
+        summary:
+          'General-purpose bladder accumulators optimized for high cycling and quick energy discharge.'
+      },
+      {
+        name: 'Accumulator Precharging Equipment',
+        summary:
+          'Portable charging rigs that let technicians set precise pre-charge pressures on site.'
+      },
+      {
+        name: 'Hydraulic Bladder Accumulators (Large Capacity)',
+        summary:
+          'High-volume accumulators delivering extended backup flow for press, molding, and forging operations.'
+      }
+    ]
+  },
+  {
+    slug: 'material-handling-and-storage-systems',
+    title: 'Material Handling and Storage Systems',
+    description:
+      'Purpose-built handling aids that improve ergonomics and tool organization on the shop floor.',
+    items: [
+      {
+        name: 'CNC Tool Holder Trolley',
+        summary:
+          'Mobile trolley system that protects tooling and keeps changeovers efficient near CNC machines.'
+      },
+      {
+        name: 'Hydraulic Floor Crane (Manual)',
+        summary:
+          'Manually pumped floor crane suited for maintenance lifts and component positioning.'
+      },
+      {
+        name: 'Hydraulic Floor Crane (Electric Assist)',
+        summary:
+          'Powered hydraulic crane that reduces operator effort when moving heavy assemblies.'
+      }
+    ]
+  },
+  {
+    slug: 'manual-clamping-accessories',
+    title: 'Manual Clamping Accessories',
+    description:
+      'Shop-proven clamps and leveling devices that secure workpieces accurately during fabrication.',
+    items: [
+      {
+        name: 'Horizontal Hold Down Action Clamp',
+        summary:
+          'Low-profile clamp delivering strong holding force without obstructing machining envelopes.'
+      },
+      {
+        name: 'Leveling Pads - Male',
+        summary:
+          'Adjustable male-thread leveling pads that stabilize fixtures and equipment.'
+      },
+      {
+        name: 'Leveling Pads Female',
+        summary:
+          'Female-thread leveling pads that pair with studs for quick machine leveling and support.'
+      }
+    ]
+  },
+  {
+    slug: 'manual-toggle-clamps',
+    title: 'Manual Toggle Clamps',
+    description:
+      'Toggle solutions for production jigs, offering repeatable clamping force with ergonomic handles.',
+    items: [
+      {
+        name: 'Steel Smith Vertical Hold Down Action Toggle Clamps',
+        summary:
+          'Vertical hold-down clamps providing reliable locking action for repetitive fabrication tasks.'
+      },
+      {
+        name: 'Steel Smith Vertical Handle Toggle Clamp',
+        summary:
+          'Compact vertical handle clamp ideal for tight work cells and assembly fixtures.'
+      },
+      {
+        name: 'Steel Smith Horizontal Hold Down Action Toggle Clamp',
+        summary:
+          'Horizontal clamp configuration that maintains clearance above the work surface.'
+      }
+    ]
+  },
+  {
+    slug: 'precision-engineering-products',
+    title: 'Precision Engineering Products',
+    description:
+      'Metrology tools and fixtures that support inspection, alignment, and precision assembly.',
+    items: [
+      {
+        name: 'Microflat Universal Bench Center',
+        summary:
+          'High-accuracy bench center for checking concentricity and runout on shafts and rollers.'
+      },
+      {
+        name: 'Microflat Cast Iron Hollow Box Parallel',
+        summary:
+          'Stress-relieved cast iron parallels that maintain squareness for layout and machining.'
+      },
+      {
+        name: 'Granite Surface Plate',
+        summary:
+          'Fine-grain granite plate offering stable reference surfaces for measurement and calibration.'
+      }
+    ]
+  },
+  {
+    slug: 'manual-powered-hand-tools-and-storage-solution',
+    title: 'Manual, Powered Hand Tools And Storage Solution',
+    description:
+      'Driver sets and ergonomic storage that keep frequently used fastening tools within reach.',
+    items: [
+      {
+        name: 'SGDP42IRBR Screw Driver',
+        summary:
+          'Precision screwdriver with interchangeable bits for assembly and service technicians.'
+      },
+      {
+        name: 'SGDX80BR Screw Drivers',
+        summary:
+          'Heavy-duty screwdriver set covering a wide torque range for industrial maintenance.'
+      },
+      {
+        name: 'SGD424BG Screw Driver',
+        summary:
+          'Ergonomic driver engineered to reduce fatigue during repetitive fastening.'
+      }
+    ]
+  },
+  {
+    slug: 'power-team-bolting-products',
+    title: 'Power Team Bolting Products',
+    description:
+      'High-accuracy bolting tools that achieve repeatable preload on mission-critical joints.',
+    items: [
+      {
+        name: 'SPX Flow Power Team Torque Wrench High Cycle',
+        summary:
+          'Electric torque wrench designed for rapid duty cycles and demanding bolting programs.'
+      },
+      {
+        name: 'TWLC SPX Flow Power Team Low Clearance Torque Wrenches',
+        summary:
+          'Low-clearance hydraulic torque wrenches tailored for confined flange bolting.'
+      },
+      {
+        name: 'SPX Flow Power Team Spring Return Tensioner',
+        summary:
+          'Spring-return tensioner that simplifies large stud tightening with even load distribution.'
+      }
+    ]
+  },
+  {
+    slug: 'power-team-hydraulic-and-mechanical-pullers',
+    title: 'Power Team Hydraulic And Mechanical Pullers',
+    description:
+      'Puller systems for removing gears, bearings, and couplings with maximum control.',
+    items: [
+      {
+        name: 'PT202 Posi-Lock Pullers',
+        summary:
+          'Self-centering mechanical puller that grips securely for safer component removal.'
+      },
+      {
+        name: 'PR2100J Hydraulic Pullers',
+        summary:
+          'Hydraulic puller set delivering high tonnage force with minimal manual effort.'
+      },
+      {
+        name: 'PH83C Puller Accessory Kits Hydra Lock-Jaw',
+        summary:
+          'Accessory kit expanding puller configurations for unique maintenance challenges.'
+      }
+    ]
+  },
+  {
+    slug: 'high-pressure-hydraulic-pumps',
+    title: 'High Pressure Hydraulic Pumps',
+    description:
+      'Manual and powered pumps delivering dependable pressure for field service tooling.',
+    items: [
+      {
+        name: 'P55 Hydraulic Hand Pumps',
+        summary:
+          'Two-stage pump with rugged construction for portable lifting and pressing jobs.'
+      },
+      {
+        name: 'Hydraulic Hand Pumps',
+        summary:
+          'General-purpose hand pumps compatible with a wide range of cylinders and tools.'
+      },
+      {
+        name: 'PA9 Hydraulic Pump',
+        summary:
+          'Air-powered pump providing consistent flow for medium-volume hydraulic circuits.'
+      }
+    ]
+  },
+  {
+    slug: 'industrial-process-pumps',
+    title: 'Industrial Process Pumps',
+    description:
+      'Process pump technologies for chemical transfer, lubrication, and circulation duties.',
+    items: [
+      {
+        name: 'Combi Norm Standardized Centrifugal Pumps',
+        summary:
+          'ISO-compliant centrifugal pumps engineered for continuous-duty process lines.'
+      },
+      {
+        name: 'Internal Gear Pumps TG Series',
+        summary:
+          'Positive-displacement internal gear pumps that handle viscous fluids smoothly.'
+      },
+      {
+        name: 'Self Priming Centrifugal Pump',
+        summary:
+          'Self-priming centrifugal design that simplifies installation on transfer skids.'
+      }
+    ]
+  },
+  {
+    slug: 'lubrication-and-mechanical-tools',
+    title: 'Lubrication and Mechanical Tools',
+    description:
+      'Maintenance kits that streamline bearing service and mechanical assembly.',
+    items: [
+      {
+        name: 'Mechanical Puller',
+        summary:
+          'Versatile puller delivering uniform force for removing press-fit components.'
+      },
+      {
+        name: 'Hydraulic Jack',
+        summary:
+          'Portable jack that offers reliable lifting capacity for service technicians.'
+      },
+      {
+        name: 'Bearing Fitting Kit',
+        summary:
+          'Comprehensive kit that helps seat bearings without damaging races or shafts.'
+      }
+    ]
+  },
+  {
+    slug: 'filtration-systems-and-separators',
+    title: 'Filtration Systems and Separators',
+    description:
+      'Coolant and chip filtration equipment that maintains fluid cleanliness and machine uptime.',
+    items: [
+      {
+        name: 'Chip Conveyor - Hinged Belt',
+        summary:
+          'Hinged-belt conveyor that efficiently removes chips from machining centers.'
+      },
+      {
+        name: 'Coolant Filtration Rotary Drum Filters',
+        summary:
+          'Rotary drum filtration delivering continuous removal of fines from coolant loops.'
+      },
+      {
+        name: 'Paper Band Filters',
+        summary:
+          'Paper media filtration that traps particulates to protect coolant pumps and tooling.'
+      }
+    ]
+  },
+  {
+    slug: 'oil-filtration-system',
+    title: 'Oil Filtration System',
+    description:
+      'Portable and fixed oil filtration skids that extend lubricant life and reduce downtime.',
+    items: [
+      {
+        name: 'Fluent Ultra H Oil Filtration System',
+        summary:
+          'High-flow filtration skid targeting particulate and water contamination in reservoirs.'
+      },
+      {
+        name: 'Oil Filtration System - Fluent Ultra XG',
+        summary:
+          'Compact purifier engineered for conditioning turbine and hydraulic oils.'
+      },
+      {
+        name: 'Oil Filtration System - Fluent TCF',
+        summary:
+          'Triple-stage cart that polishes fluids during commissioning or after maintenance.'
+      }
+    ]
+  },
+  {
+    slug: 'pneumatic-hand-tools',
+    title: 'Pneumatic Hand Tools',
+    description:
+      'Air-powered tools that deliver dependable torque, sanding, and cutting performance.',
+    items: [
+      {
+        name: 'Cordless Impact Wrench',
+        summary:
+          'Battery-driven impact wrench offering pneumatic-like torque with mobile convenience.'
+      },
+      {
+        name: 'PT430 Air Sander',
+        summary:
+          'Lightweight air sander providing smooth surface finishing and minimal vibration.'
+      },
+      {
+        name: 'CT8850G Drive Monster Lithium Impact Wrench',
+        summary:
+          'High-output impact wrench with lithium power ideal for heavy equipment service.'
+      }
+    ]
+  },
+  {
+    slug: 'solvent-recovery-systems',
+    title: 'Solvent Recovery Systems',
+    description:
+      'Systems that reclaim cleaning solvents to reduce waste and operating costs.',
+    items: [
+      {
+        name: 'Solvent Recovery System (Batch)',
+        summary:
+          'Batch distillation unit recovering usable solvent from contaminated streams.'
+      },
+      {
+        name: 'Solvent Recovery (Continuous)',
+        summary:
+          'Continuous recovery system suited for high-volume cleaning and degreasing lines.'
+      },
+      {
+        name: 'Solvent Recycling Unit',
+        summary:
+          'Automated recycler that lowers disposal costs and keeps solvent quality consistent.'
+      }
+    ]
+  },
+  {
+    slug: 'heat-exchangers',
+    title: 'Heat Exchanger',
+    description:
+      'Brazed plate designs that maximize heat transfer in compact hydraulic and HVAC packages.',
+    items: [
+      {
+        name: 'Brazed Plate Heat Exchanger (Industrial)',
+        summary:
+          'High-efficiency exchanger sized for hydraulic oil cooling and process duties.'
+      },
+      {
+        name: 'Brazed Plate Heat Exchanger (HVAC)',
+        summary:
+          'Optimized plate pack for chillers, heat pumps, and building services.'
+      },
+      {
+        name: 'Brazed Plate Heat Exchanger (Compact)',
+        summary:
+          'Space-saving exchanger suited for OEM equipment and retrofit installations.'
+      }
+    ]
+  },
+  {
+    slug: 'hydraulic-jack-solutions',
+    title: 'Hydraulic Jack',
+    description:
+      'Lifting and power pack solutions that tackle bearing extraction and onsite repairs.',
+    items: [
+      {
+        name: 'Hydraulic Bearing Puller Set',
+        summary:
+          'Integrated jack and puller set simplifying the removal of stubborn bearings.'
+      },
+      {
+        name: 'Electric Hydraulic Power Pack',
+        summary:
+          'Compact electric power pack delivering consistent pressure to hydraulic jacks and tools.'
+      }
+    ]
+  },
+  {
+    slug: 'anti-vibration-pad',
+    title: 'Anti Vibration Pad',
+    description:
+      'Vibration-damping solutions that protect sensitive equipment and reduce noise.',
+    items: [
+      {
+        name: 'Anti Vibration Pads',
+        summary:
+          'High-density pads absorbing shock and vibration under machinery, compressors, and pumps.'
+      }
+    ]
+  },
+  {
+    slug: 'foot-pump',
+    title: 'Foot Pump',
+    description:
+      'Hands-free hydraulic pumping ideal for clamping, pressing, and maintenance fixtures.',
+    items: [
+      {
+        name: 'Hydraulic Foot Pump',
+        summary:
+          'Durable foot-operated pump that leaves both hands free to position workpieces safely.'
+      }
+    ]
+  },
+  {
+    slug: 'industrial-pumps-spx-flow-johnson-pump',
+    title: 'Industrial Pumps - SPX Flow Johnson Pump',
+    description:
+      'Engineered centrifugal pumps from SPX Flow for demanding chemical and utility service.',
+    items: [
+      {
+        name: 'Chemical Centrifugal Pump Combi Chem SPX Flow',
+        summary:
+          'Chemically resistant centrifugal pump meeting stringent process safety requirements.'
+      }
+    ]
+  },
+  {
+    slug: 'filter-media',
+    title: 'Filter Media',
+    description:
+      'Consumable filter media tailored for coolant filtration units and oil conditioning systems.',
+    items: [
+      {
+        name: 'Filter Media',
+        summary:
+          'High-retention media rolls sized for paper band and vacuum filtration equipment.'
+      }
+    ]
+  },
+  {
+    slug: 'torque-wrenches',
+    title: 'Torque Wrenches',
+    description:
+      'Torque multiplication solutions that help teams break free seized fasteners safely.',
+    items: [
+      {
+        name: 'Torque Multiplier',
+        summary:
+          'Compact torque multiplier delivering high output torque with minimal input effort.'
+      }
+    ]
+  },
+  {
+    slug: 'hydraulic-stacker',
+    title: 'Hydraulic Stacker',
+    description:
+      'Battery-assisted stackers that raise pallets and dies with precise hydraulic control.',
+    items: [
+      {
+        name: 'Battery Operated Hydraulic Stackers',
+        summary:
+          'Powered stacker combining electric drive and hydraulic lift for effortless material handling.'
+      }
+    ]
+  }
+];

--- a/styles/ProductRangeDetail.module.css
+++ b/styles/ProductRangeDetail.module.css
@@ -1,0 +1,32 @@
+.grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 1.5rem;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.card p {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.5;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.5rem;
+  }
+}

--- a/styles/ProductRangeGrid.module.css
+++ b/styles/ProductRangeGrid.module.css
@@ -1,0 +1,64 @@
+.grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 1.75rem;
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.08);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.header p {
+  margin: 0.5rem 0 0;
+  color: #475569;
+}
+
+.list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.itemName {
+  font-weight: 600;
+}
+
+.list p {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.45;
+}
+
+.link {
+  margin-top: auto;
+  align-self: flex-start;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+@media (max-width: 640px) {
+  .card {
+    border-radius: 1.5rem;
+    padding: 1.5rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a hydraulic equipment range landing page with a category grid and navigation entry
- create structured product range data and dynamic detail pages for each hydraulic category
- style new range overview and detail components to match existing UI patterns

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e0fb762a7c832787847a8b57948580